### PR TITLE
Fixed crash when a force was created before on_config_changed

### DIFF
--- a/KingsTurret-Shields/prototypes/functions.lua
+++ b/KingsTurret-Shields/prototypes/functions.lua
@@ -481,6 +481,10 @@ function update_electricity_force(force)
 	if DEBUG then
 		log("debug update_electricity_force " .. force.name)
 	end
+
+	if global.forces[force.name] == nil then
+		global.forces[force.name] = {}
+	end
 	
 	if global.research_enabled and force.technologies["turret-shields-base"].researched then
 		global.forces[force.name].enabled = true


### PR DESCRIPTION
Fixes https://mods.factorio.com/mod/AbandonedRuins/discussion/5f8f09ce0d7d24f1b34f209e and presumably also https://mods.factorio.com/mod/KingsTurret-Shields/discussion/5f7766ee7d9446922ae40328

The problem is that global.forces[force_name] is nil for the new force created by the ruins mod. So global.forces[force_name] is now created in "update_electricity_force", which is the same behaviour as "update_force".

I tested the fix with an otherwise empty save and it worked.