### PR TITLE
Separate flywheels from accumulators for upgrades

### DIFF
--- a/EnhancedGridEnergyStores/prototypes/entity/energy-stores.lua
+++ b/EnhancedGridEnergyStores/prototypes/entity/energy-stores.lua
@@ -137,6 +137,11 @@ entity_flywheel.energy_source = {
     usage_priority = "tertiary"
 }
 
+-- Due to the bounding box size change, this entity is not compatible with accumulators
+-- for upgrade planners. This may cause breakage with other mods if they make accumulators upgradable
+entity_flywheel.next_upgrade = nil
+entity_flywheel.fast_replaceable_group = nil
+
 data:extend({entity_flywheel})
 
 --/////////////////////


### PR DESCRIPTION
Some mods may modify the base accumulator to make it usable
for upgrade planners. Since the flywheel is a different size this will
cause an error on startup.